### PR TITLE
메일 서버 연결 실패시 재시도 로직 추가, 사용자로 오류 시 로그 레벨 warn 설정, 로그에 스택트레이스 추가

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework:spring-aspects'
 }
 
 tasks.named('test') {

--- a/be/src/main/java/airdnb/be/BeApplication.java
+++ b/be/src/main/java/airdnb/be/BeApplication.java
@@ -2,7 +2,9 @@ package airdnb.be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
 
+@EnableRetry
 @SpringBootApplication
 public class BeApplication {
 

--- a/be/src/main/java/airdnb/be/config/WebConfig.java
+++ b/be/src/main/java/airdnb/be/config/WebConfig.java
@@ -19,6 +19,6 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(new LoginCheckInterceptor())
                 .order(2)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/member", "/member/exist", "/member/email/authenticate", "member/login");
+                .excludePathPatterns("/member", "/member/exist", "/member/email/authenticate", "/member/login");
     }
 }

--- a/be/src/main/java/airdnb/be/domain/member/service/EmailService.java
+++ b/be/src/main/java/airdnb/be/domain/member/service/EmailService.java
@@ -61,6 +61,6 @@ public class EmailService {
         if (redisUtils.hasData(authCode, email)) {
             return;
         }
-        throw new BusinessException(ErrorCode.AUTH_CODE_MISMATCH);
+        throw new BusinessException(ErrorCode.AUTH_MISMATCH);
     }
 }

--- a/be/src/main/java/airdnb/be/domain/member/service/EmailService.java
+++ b/be/src/main/java/airdnb/be/domain/member/service/EmailService.java
@@ -63,4 +63,19 @@ public class EmailService {
         }
         throw new BusinessException(ErrorCode.AUTH_MISMATCH);
     }
+
+    public void setVerifiedEmail(String email, Object sessionAttribute) {
+        if (sessionAttribute == null) {
+            throw new BusinessException(ErrorCode.AUTH_MISMATCH);
+        }
+        redisUtils.addData(email, (String) sessionAttribute);
+    }
+
+    public void verifiedEmail(String email, Object sessionAttribute) {
+        if (sessionAttribute != null && redisUtils.hasData(email, (String) sessionAttribute)) {
+            redisUtils.deleteData(email);
+            return;
+        }
+        throw new BusinessException(ErrorCode.AUTH_MISMATCH);
+    }
 }

--- a/be/src/main/java/airdnb/be/domain/member/service/MemberService.java
+++ b/be/src/main/java/airdnb/be/domain/member/service/MemberService.java
@@ -34,7 +34,7 @@ public class MemberService {
 
     public void login(String email, String password) {
         Optional.ofNullable(memberRepository.findMemberByEmail(email))
-                .map(member -> member.hasPassword(password))
+                .filter(member -> member.hasPassword(password))
                 .orElseThrow(() -> {
                     log.warn("'{}'의 로그인 정보가 정확하지 않습니다", email);
                     return new BusinessException(ErrorCode.CANNOT_LOGIN);

--- a/be/src/main/java/airdnb/be/exception/ErrorCode.java
+++ b/be/src/main/java/airdnb/be/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 
     // 회원
     ALREADY_EXISTS_MEMBER("1000", HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
+    CANNOT_LOGIN("1001", HttpStatus.BAD_REQUEST, "아이디나 비밀번호가 틀렸습니다"),
 
     // 인증
     AUTH_MISMATCH("1100", HttpStatus.BAD_REQUEST, "인증 되지 않았습니다"),

--- a/be/src/main/java/airdnb/be/exception/ErrorCode.java
+++ b/be/src/main/java/airdnb/be/exception/ErrorCode.java
@@ -14,7 +14,9 @@ public enum ErrorCode {
 
     // 인증
     AUTH_MISMATCH("1100", HttpStatus.BAD_REQUEST, "인증 되지 않았습니다"),
-    ;
+
+    // 외부 API
+    MAIL_SERVER_ERROR("2000", HttpStatus.INTERNAL_SERVER_ERROR, "내부 오류입니다. 이용에 불편을 드려서 죄송합니다");
 
     private final String code;
     private final HttpStatus status;

--- a/be/src/main/java/airdnb/be/exception/ErrorCode.java
+++ b/be/src/main/java/airdnb/be/exception/ErrorCode.java
@@ -12,7 +12,7 @@ public enum ErrorCode {
     ALREADY_EXISTS_MEMBER("1000", HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
 
     // 인증
-    AUTH_CODE_MISMATCH("1100", HttpStatus.BAD_REQUEST, "인증 번호가 일치하지 않습니다"),
+    AUTH_MISMATCH("1100", HttpStatus.BAD_REQUEST, "인증 되지 않았습니다"),
     ;
 
     private final String code;

--- a/be/src/main/java/airdnb/be/exception/ExceptionHandlers.java
+++ b/be/src/main/java/airdnb/be/exception/ExceptionHandlers.java
@@ -16,6 +16,18 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class ExceptionHandlers {
 
     /**
+     * @param ex 사용자에 의해 자주 생기는 오류를 로그 레벨 WARN 으로 처리
+     */
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleHttpClientErrorEx(HttpClientErrorException ex) {
+        log.warn("message: {}, statusText: {}", ex.getMessage(), ex.getStatusText(), ex);
+        HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
+
+        return ErrorResponse.of(status, ex.getMessage());
+    }
+
+    /**
      * 헤더의 미디어타입과 컨트롤러 argument 클래스 타입에 따라 선택된 HttpMessageConverter가 요청 본문을 읽을 수 없을 때
      */
     @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/be/src/main/java/airdnb/be/utils/RedisUtils.java
+++ b/be/src/main/java/airdnb/be/utils/RedisUtils.java
@@ -16,9 +16,17 @@ public class RedisUtils {
         redisTemplate.opsForValue().set(key, value, expiredTime, timeUnit);
     }
 
+    public void addData(String key, String value) {
+        redisTemplate.opsForValue().set(key, value);
+    }
+
     public boolean hasData(String key, String value) {
         return Optional.ofNullable(redisTemplate.opsForValue().get(key))
                 .map(redisValue -> redisValue.equals(value))
                 .orElse(false);
+    }
+
+    public void deleteData(String key) {
+        redisTemplate.delete(key);
     }
 }

--- a/be/src/main/java/airdnb/be/web/member/MemberController.java
+++ b/be/src/main/java/airdnb/be/web/member/MemberController.java
@@ -63,19 +63,18 @@ public class MemberController {
     public void addMember(@RequestBody @Valid MemberSaveRequest request, HttpSession httpSession) {
         Object sessionAttribute = httpSession.getAttribute(VERIFIED_MEMBER);
         if (sessionAttribute == null) {
-            return;
+            throw new HttpClientErrorException("인증되지 않은 회원입니다", HttpStatus.BAD_REQUEST, "BAD_REQUEST", null, null, null);
         }
         httpSession.invalidate();
         memberService.addMember(request.toMember());
     }
 
     @PostMapping("/login")
-    public ResponseEntity<Void> login(@RequestBody @Valid MemberLoginRequest request, HttpSession httpSession) {
-        boolean canLogin = memberService.login(request.email(), request.password());
-        if (canLogin) {
+    public void login(@RequestBody @Valid MemberLoginRequest request, HttpSession httpSession) {
+        boolean login = memberService.login(request.email(), request.password());
+        if (login) {
             httpSession.setAttribute(LOGIN_MEMBER, true);
-            return new ResponseEntity<>(HttpStatus.OK);
         }
-        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        throw new HttpClientErrorException("아이디와 비밀번호가 일치하지 않습니다", HttpStatus.BAD_REQUEST, "BAD_REQUEST", null, null, null);
     }
 }

--- a/be/src/main/java/airdnb/be/web/member/MemberController.java
+++ b/be/src/main/java/airdnb/be/web/member/MemberController.java
@@ -63,8 +63,10 @@ public class MemberController {
     public void addMember(@RequestBody @Valid MemberSaveRequest request, HttpSession httpSession) {
         Object sessionAttribute = httpSession.getAttribute(VERIFIED_MEMBER);
         if (sessionAttribute == null) {
-            throw new HttpClientErrorException("인증되지 않은 회원입니다", HttpStatus.BAD_REQUEST, "BAD_REQUEST", null, null, null);
+            log.warn("'{}'는 인증되지 않은 회원입니다", request.email());
+            throw new BusinessException(ErrorCode.AUTH_MISMATCH);
         }
+        emailService.authenticateEmail(request.authCode(), request.email());
         httpSession.invalidate();
         memberService.addMember(request.toMember());
     }

--- a/be/src/main/java/airdnb/be/web/member/MemberController.java
+++ b/be/src/main/java/airdnb/be/web/member/MemberController.java
@@ -69,10 +69,7 @@ public class MemberController {
 
     @PostMapping("/login")
     public void login(@RequestBody @Valid MemberLoginRequest request, HttpSession httpSession) {
-        boolean login = memberService.login(request.email(), request.password());
-        if (login) {
-            httpSession.setAttribute(LOGIN_MEMBER, true);
-        }
-        throw new HttpClientErrorException("아이디와 비밀번호가 일치하지 않습니다", HttpStatus.BAD_REQUEST, "BAD_REQUEST", null, null, null);
+        memberService.login(request.email(), request.password());
+        httpSession.setAttribute(LOGIN_MEMBER, true);
     }
 }

--- a/be/src/main/java/airdnb/be/web/member/MemberController.java
+++ b/be/src/main/java/airdnb/be/web/member/MemberController.java
@@ -46,9 +46,10 @@ public class MemberController {
     이메일 인증번호 확인
      */
     @GetMapping("/email/authenticate")
-    public void authenticateEmail(@RequestBody @Valid EmailAuthenticationRequest request, HttpSession httpSession) {
-        emailService.authenticateEmail(request.authCode(), request.email());
-        httpSession.setAttribute(VERIFIED_MEMBER, true);
+    public void authenticateEmail(@RequestBody @Valid EmailAuthenticationRequest request, HttpSession session) {
+        emailService.authenticateEmail(request.authCode(), request.email()); // 인증번호 확인
+        session.setAttribute(VERIFIED_MEMBER, true); // 세션 설정
+        emailService.setVerifiedEmail(request.email(), session.getAttribute(VERIFIED_MEMBER)); // 검증된 이메일 추가
     }
 
     /*
@@ -60,14 +61,9 @@ public class MemberController {
     }
 
     @PostMapping
-    public void addMember(@RequestBody @Valid MemberSaveRequest request, HttpSession httpSession) {
-        Object sessionAttribute = httpSession.getAttribute(VERIFIED_MEMBER);
-        if (sessionAttribute == null) {
-            log.warn("'{}'는 인증되지 않은 회원입니다", request.email());
-            throw new BusinessException(ErrorCode.AUTH_MISMATCH);
-        }
-        emailService.authenticateEmail(request.authCode(), request.email());
-        httpSession.invalidate();
+    public void addMember(@RequestBody @Valid MemberSaveRequest request, HttpSession session) {
+        emailService.verifiedEmail(request.email(), session.getAttribute(VERIFIED_MEMBER)); // 검증된 이메일로 요청이 왔는지 확인
+        session.invalidate();
         memberService.addMember(request.toMember());
     }
 

--- a/be/src/main/java/airdnb/be/web/member/request/MemberSaveRequest.java
+++ b/be/src/main/java/airdnb/be/web/member/request/MemberSaveRequest.java
@@ -20,10 +20,7 @@ public record MemberSaveRequest(
         String phoneNumber,
 
         @NotBlank
-        String password,
-
-        @NotNull
-        String authCode
+        String password
 ) {
     public Member toMember() {
         return new Member(name, email, phoneNumber, password);

--- a/be/src/main/java/airdnb/be/web/member/request/MemberSaveRequest.java
+++ b/be/src/main/java/airdnb/be/web/member/request/MemberSaveRequest.java
@@ -20,7 +20,10 @@ public record MemberSaveRequest(
         String phoneNumber,
 
         @NotBlank
-        String password
+        String password,
+
+        @NotNull
+        String authCode
 ) {
     public Member toMember() {
         return new Member(name, email, phoneNumber, password);

--- a/be/src/test/java/airdnb/be/web/member/request/MemberSaveRequestTest.java
+++ b/be/src/test/java/airdnb/be/web/member/request/MemberSaveRequestTest.java
@@ -19,7 +19,7 @@ class MemberSaveRequestTest {
     @ValueSource(strings = {"", " "})
     void validateMemberName(String name) {
         // given
-        MemberSaveRequest request = new MemberSaveRequest(name, "gromit123@naver.com", "010-1234-5678");
+        MemberSaveRequest request = new MemberSaveRequest(name, "gromit123@naver.com", "010-1234-5678", "password");
 
         // when
         Set<ConstraintViolation<MemberSaveRequest>> violations = validator.validate(request);
@@ -33,7 +33,7 @@ class MemberSaveRequestTest {
     @ValueSource(strings = {"dkswhdgur", "@naver.com", "", " "})
     void validateMemberEmail(String email) {
         // given
-        MemberSaveRequest request = new MemberSaveRequest("jong", email, "010-1234-5678");
+        MemberSaveRequest request = new MemberSaveRequest("jong", email, "010-1234-5678", "password");
 
         // when
         Set<ConstraintViolation<MemberSaveRequest>> violations = validator.validate(request);
@@ -47,7 +47,7 @@ class MemberSaveRequestTest {
     @ValueSource(strings = {"010-113-1234", "", "010-1234-54676", "010-1234-547I"})
     void validateMemberPhoneNumber(String phoneNumber) {
         // given
-        MemberSaveRequest request = new MemberSaveRequest("jong", "gromit1234@naver.com", phoneNumber);
+        MemberSaveRequest request = new MemberSaveRequest("jong", "gromit1234@naver.com", phoneNumber, "password");
 
         // when
         Set<ConstraintViolation<MemberSaveRequest>> violations = validator.validate(request);


### PR DESCRIPTION
## 메일 서버에 연결 실패 시 재시도 로직 추가
외부 메일 서버에 네트워크 오류로 인해 요청에 실패 시 재시도 하는 로직을 추가하였습니다. 3번 요청에 실패하면 로그 레벨을 error 로 남겨 추후에 error 인 로그 같은 경우 알림을 보내서 다른 외부 메일 서버를 이용하기 위해서 추가하였습니다.
참고자료 : https://www.baeldung.com/spring-retry

## 사용자에 의한 오류의 log레벨을 warn 으로 설정
사용자에 의한 예외(비밀번호 잘못 입력, 인증번호 잘못 입력)와 같은 것은 즉각적인 조치를 취해야 하는 error 레벨 보다는 warn 레벨이 적합하다 판단해서 warn 레벨로 설정하였습니다.

close #10 #11